### PR TITLE
Favor volume mounting over file system mounting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,33 @@ data/env.yml:
 	git submodule update
 	./data/prepare.rb
 
+data_volume:
+	(docker volume ls | grep "codeclimate_shellcheck_data") || docker volume create "codeclimate_shellcheck_data"
+
 build:
 	docker build \
 	  --tag $(IMAGE_NAME)-build \
 	  --file $(PWD)/docker/Build.plan .
 
-.local/bin/codeclimate-shellcheck: build
+.local/bin/codeclimate-shellcheck: build data_volume
 	docker run --rm \
-	  --volume $(PWD)/.local/bin:/root/.local/bin \
+	  --volume codeclimate_shellcheck_data:/root/.local/bin \
 	  --volume $(PWD)/.local/.stack:/root/.stack \
 	  --volume $(PWD)/.local/.stack-work:/home/app/.stack-work \
 	  $(IMAGE_NAME)-build stack install
 
-compress: .local/bin/codeclimate-shellcheck
+compress: .local/bin/codeclimate-shellcheck data_volume
 	docker run \
-	  --volume $(PWD)/.local/bin:/data \
+	  --volume codeclimate_shellcheck_data:/data \
 	  lalyos/upx codeclimate-shellcheck
 
-image: .local/bin/codeclimate-shellcheck data/env.yml
+image: .local/bin/codeclimate-shellcheck data/env.yml data_volume
+	mkdir -p .local/bin
+	docker run --volume codeclimate_shellcheck_data:/data \
+		--name codeclimate_shellcheck_build_helper \
+		$(IMAGE_NAME)-build true
+	docker cp codeclimate_shellcheck_build_helper:/data/codeclimate-shellcheck .local/bin
+	docker rm codeclimate_shellcheck_build_helper
 	docker build \
 	  --tag $(IMAGE_NAME) \
 	  --file $(PWD)/docker/Release.plan .


### PR DESCRIPTION
We were running into some issues getting this to build on CI. While the
image built fine locally, on CI, we'd hit an error at the step in the
docker file `Release.plan` where we tried to `ADD
.local/bin/codeclimate-shellcheck /home/app/bin/engine`. Will did some
digging and was able to determine that we likely needed to volume mount
instead.

Co-authored-by: Will Fleming <will@flemi.ng>