### PR TITLE
Revert "Favor volume mounting over file system mounting"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,33 +7,24 @@ data/env.yml:
 	git submodule update
 	./data/prepare.rb
 
-data_volume:
-	(docker volume ls | grep "codeclimate_shellcheck_data") || docker volume create "codeclimate_shellcheck_data"
-
 build:
 	docker build \
 	  --tag $(IMAGE_NAME)-build \
 	  --file $(PWD)/docker/Build.plan .
 
-.local/bin/codeclimate-shellcheck: build data_volume
+.local/bin/codeclimate-shellcheck: build
 	docker run --rm \
-	  --volume codeclimate_shellcheck_data:/root/.local/bin \
+	  --volume $(PWD)/.local/bin:/root/.local/bin \
 	  --volume $(PWD)/.local/.stack:/root/.stack \
 	  --volume $(PWD)/.local/.stack-work:/home/app/.stack-work \
 	  $(IMAGE_NAME)-build stack install
 
-compress: .local/bin/codeclimate-shellcheck data_volume
+compress: .local/bin/codeclimate-shellcheck
 	docker run \
-	  --volume codeclimate_shellcheck_data:/data \
+	  --volume $(PWD)/.local/bin:/data \
 	  lalyos/upx codeclimate-shellcheck
 
-image: .local/bin/codeclimate-shellcheck data/env.yml data_volume
-	mkdir -p .local/bin
-	docker run --volume codeclimate_shellcheck_data:/data \
-		--name codeclimate_shellcheck_build_helper \
-		$(IMAGE_NAME)-build true
-	docker cp codeclimate_shellcheck_build_helper:/data/codeclimate-shellcheck .local/bin
-	docker rm codeclimate_shellcheck_build_helper
+image: .local/bin/codeclimate-shellcheck data/env.yml
 	docker build \
 	  --tag $(IMAGE_NAME) \
 	  --file $(PWD)/docker/Release.plan .


### PR DESCRIPTION
Reverts codeclimate-community/codeclimate-shellcheck#1

- This caused another issue:

```
Digest: sha256:3b3383f8f0199f8dfab9fc3a31fe003029e04c4f655d077871f0d205e5b09082
Status: Downloaded newer image for codeclimate/codeclimate-shellcheck:latest
/home/app/bin/engine: /usr/glibc-compat/lib/libm.so.6: version `GLIBC_2.27' not found (required by /home/app/bin/engine)
```
Going to revert for now and take another look at this next week.